### PR TITLE
Updated Odoo's port section & traefik port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,6 @@ services:
     restart: unless-stopped
     networks:
       - internal
-    ports:
-      - "8069:8069"
-      - "8072:8072"
     environment:
       - HOST=db
       - USER=${ODOO_USER}
@@ -23,7 +20,7 @@ services:
       - 'traefik.http.routers.odoo.rule=Host(`${ODOO_TRAEFIK_URL}`)'
       - 'traefik.http.routers.odoo.entrypoints=websecure'
       - 'traefik.http.routers.odoo.tls.certresolver=odoo'
-      - 'traefik.port=8069'
+      - "traefik.http.services.odoo.loadbalancer.server.port=8069"
       - "traefik.http.routers.http-catchall.rule=hostregexp(`{host:.+}`)"
       - "traefik.http.routers.http-catchall.entrypoints=web"
       - "traefik.http.routers.http-catchall.middlewares=redirect-to-https@docker"


### PR DESCRIPTION
If we're using Traefik, we don't need to declare the ports in the odoo service.
Updated 'traefik.port=8069' (1.x syntax) to 2.x syntax,